### PR TITLE
Feature: Optional Outputs

### DIFF
--- a/src/main/groovy/br/ufscar/sead/loa/propeller/domain/TaskDefinition.groovy
+++ b/src/main/groovy/br/ufscar/sead/loa/propeller/domain/TaskDefinition.groovy
@@ -28,6 +28,7 @@ class TaskDefinition extends Mistakable {
     // dependencies TODO
     @Embedded
     ArrayList<TaskOutputDefinition> outputs
+    ArrayList<TaskOutputDefinition> optionalOutputs
 
 
     TaskDefinition() {}
@@ -43,9 +44,14 @@ class TaskDefinition extends Mistakable {
         ArrayList<Document> outputs = doc.get('outputs') as ArrayList<Document>
 
         this.outputs = new ArrayList<TaskOutputDefinition>()
+        this.optionalOutputs = new ArrayList<TaskOutputDefinition>()
 
         outputs.each { output ->
-            this.outputs.add(new TaskOutputDefinition(output))
+            if(output.getBoolean("optional")) {
+                this.optionalOutputs.add(new TaskOutputDefinition(output))
+            } else {
+                this.outputs.add(new TaskOutputDefinition(output))
+            }
         }
 
         Propeller.instance.ds.save(this)

--- a/src/main/groovy/br/ufscar/sead/loa/propeller/domain/TaskInstance.groovy
+++ b/src/main/groovy/br/ufscar/sead/loa/propeller/domain/TaskInstance.groovy
@@ -89,13 +89,8 @@ class TaskInstance {
      * @return true if the files matches what the task expects or false otherwise.
      */
     boolean complete(String... paths) {
+        // A task can only be completed if it's pending
         if (this.status != STATUS_PENDING) {
-            return false
-        }
-
-        // A task should not be completed with more or less outputs than its definition
-        if (paths.size() != this.definition.outputs.size()) {
-            println 'task ' + this.id + " not completed: paths count != expected"
             return false
         }
 
@@ -107,19 +102,28 @@ class TaskInstance {
             this.outputs.add(null)
         }
 
-        def count = 0
+        def requiredOutputs = 0
+        def optionalOutputs = 0
         for (path in paths) {
             def fileName = path.substring(path.lastIndexOf('/') + 1) // extract fileName from full path
             this.definition.outputs.eachWithIndex { output, i -> // loop through
                 if (output.name == fileName) {
+                    if (output.optional) {
+                        optionalOutputs++
+                    } else {
+                        requiredOutputs++
+                    }
                     this.outputs.set(i, new TaskOutputInstance(output, path))
-                    count++
+                } else {
+                    return false
                 }
             }
         }
 
-        // if the number of matched paths is != from the number of expected, the completion should fail
-        if (count != this.definition.outputs.size()) {
+        // All required outputs must have a matching path, otherwise the completion fails
+        // All remaining paths must match with an optional output and must not exceed the
+        // number of optional outputs defined by the task
+        if (requiredOutputs != this.definition.outputs.size() && optionalOutputs <= this.definition.optionalOutputs.size()) {
             this.outputs = null
             println 'task ' + this.id + " not completed: count != expected"
             return false

--- a/src/main/groovy/br/ufscar/sead/loa/propeller/domain/TaskInstance.groovy
+++ b/src/main/groovy/br/ufscar/sead/loa/propeller/domain/TaskInstance.groovy
@@ -104,11 +104,12 @@ class TaskInstance {
 
         def requiredOutputs = 0
         def optionalOutputs = 0
+
         for (path in paths) {
             def fileName = path.substring(path.lastIndexOf('/') + 1) // extract fileName from full path
-            this.definition.outputs.eachWithIndex { output, i -> // loop through
+            this.definition.outputs.eachWithIndex { output, i -> // loop through all output definitions
                 if (output.name == fileName) {
-                    if (output.optional) {
+                    if (output.optional) { // Checks if the output is defined as optional
                         optionalOutputs++
                     } else {
                         requiredOutputs++
@@ -134,8 +135,9 @@ class TaskInstance {
         this.process.pendingTasks.remove(this)
         this.process.completedTasks.add(this)
 
+        // Checks if any obligatory task is still pending; Otherwhise, the process can be updated to complete
         if ( !this.process.pendingTasks.any { task -> !(task.definition.optional) } ) {
-            this.process.status = ProcessInstance.STATUS_ALL_TASKS_COMPLETED
+            this.process.status = ProcessInstance.STATUS_ALL_TASKS_COMPLETED // Process complete
         }
 
         Propeller.instance.ds.save(this.process, this)

--- a/src/main/groovy/br/ufscar/sead/loa/propeller/domain/TaskOutputDefinition.groovy
+++ b/src/main/groovy/br/ufscar/sead/loa/propeller/domain/TaskOutputDefinition.groovy
@@ -14,6 +14,7 @@ class TaskOutputDefinition extends Mistakable {
     String name
     String type
     String path
+    boolean optional
 
     TaskOutputDefinition() {}
 
@@ -21,6 +22,7 @@ class TaskOutputDefinition extends Mistakable {
         this.name = doc.getString('name')
         this.type = doc.getString('type')
         this.path = doc.getString('path')
+        this.optional = doc.getBoolean('optional')
     }
 
     @Override

--- a/test/resources/forca.json
+++ b/test/resources/forca.json
@@ -55,6 +55,26 @@
           "path": "/imgs"
         }
       ]
+    },
+    {
+      "name": "Tarefa com Output Opcional",
+      "uri": "optional",
+      "description": "Uma tarefa opcional para teste",
+      "type": "image_collection",
+      "dependencies": null,
+      "outputs": [
+        {
+          "name": "opcional.json",
+          "optional": true,
+          "type": "json",
+          "path": "/json"
+        },
+        {
+          "name": "papel.png",
+          "type": "image",
+          "path": "/imgs"
+        }
+      ]
     }
   ]
 }

--- a/test/unit/br/ufscar/sead/loa/propeller/PropellerSpec.groovy
+++ b/test/unit/br/ufscar/sead/loa/propeller/PropellerSpec.groovy
@@ -69,7 +69,7 @@ class PropellerSpec extends Specification {
         then:
         instance.definition.uri == 'forca'
         instance.ownerId == 1
-        instance.pendingTasks.size() == 3
+        instance.pendingTasks.size() == 4
 
         cleanup:
         propeller.ds.delete(definition)

--- a/test/unit/br/ufscar/sead/loa/propeller/TaskDefinitionSpec.groovy
+++ b/test/unit/br/ufscar/sead/loa/propeller/TaskDefinitionSpec.groovy
@@ -51,7 +51,6 @@ class TaskDefinitionSpec extends Specification {
         setup:
         def doc
         doc = Document.parse(new File('test/resources/forca.json').text).get('tasks').get(2) as Document
-        doc = Document.parse(doc.toJson().replace('perguntas.json', ''))
         definition = new TaskDefinition(doc)
 
         expect:
@@ -64,11 +63,35 @@ class TaskDefinitionSpec extends Specification {
         setup:
         def doc
         doc = Document.parse(new File('test/resources/forca.json').text).get('tasks').first() as Document
-        doc = Document.parse(doc.toJson().replace('perguntas.json', ''))
         definition = new TaskDefinition(doc)
 
         expect:
         !definition.optional;
+    }
+
+    def "create a task with optional output"() {
+        def definition
+
+        setup:
+        def doc
+        doc = Document.parse(new File('test/resources/forca.json').text).get('tasks').get(3) as Document
+        definition = new TaskDefinition(doc)
+
+        expect:
+        definition.optionalOutputs.size() == 1
+        definition.optionalOutputs.get(0).name == "opcional.json"
+    }
+
+    def "create a task with output required by default"() {
+        def definition
+
+        setup:
+        def doc
+        doc = Document.parse(new File('test/resources/forca.json').text).get('tasks').first() as Document
+        definition = new TaskDefinition(doc)
+
+        expect:
+        definition.optionalOutputs.size() == 0
     }
 
 }


### PR DESCRIPTION
O Santo Grau dá a possibilidade do usuário, em uma de suas fases, utilizar um número variável de imagens.

Para tornar essa feature possível, precisamos declarar no seu process.json todas as imagens que o jogo poderá usar, dependendo da vontade do usuário. Ao mesmo tempo, precisamos de uma forma de indicar que nem sempre aquelas imagens vão ser enviadas pelo usuário da plataforma Remar.

Utilizando uma flag optional no output, podemos indicar que um output pode ser enviado com aquela descrição pro propeller, mas que não é sempre necessário para que a tarefa seja concluida.
